### PR TITLE
added comma

### DIFF
--- a/neo4jtut/neo4jtut/generic_settings.py
+++ b/neo4jtut/neo4jtut/generic_settings.py
@@ -88,5 +88,5 @@ STATICFILES_DIRS = (
 )
 
 TEMPLATE_DIRS = (
-    os.path.join(BASE_DIR, 'templates')
+    os.path.join(BASE_DIR, 'templates'),
 )


### PR DESCRIPTION
Didn't work without the comma on Windows 7 (64-bit).
Got the error "TEMPLATE_DIRS must be a tuple".
